### PR TITLE
Disable session filter for daily timeframe

### DIFF
--- a/MQL4/Experts/CCTS_Breakout.mq4
+++ b/MQL4/Experts/CCTS_Breakout.mq4
@@ -195,15 +195,19 @@ void OnTick()
    if(!IsDayAllowed())
       return;
 
-// If *all* toggles are off, skip filtering entirely:
-   if(!(!EnableAsianSession && !EnableLondonSession && !EnableNewYorkSession))
+// Skip session filtering for the Daily timeframe
+   if(Period() != PERIOD_D1)
      {
-      // otherwise require at least one enabled session to be active
-      if(!((EnableAsianSession     && inAsia)
-           ||(EnableLondonSession  && inLondon)
-           ||(EnableNewYorkSession && inNY)))
+// If *all* toggles are off, skip filtering entirely:
+      if(!(!EnableAsianSession && !EnableLondonSession && !EnableNewYorkSession))
         {
-         return;  // outside your chosen session windows
+         // otherwise require at least one enabled session to be active
+         if(!((EnableAsianSession     && inAsia)
+              ||(EnableLondonSession  && inLondon)
+              ||(EnableNewYorkSession && inNY)))
+           {
+            return;  // outside your chosen session windows
+           }
         }
      }
 


### PR DESCRIPTION
## Summary
- skip session filtering when chart period is D1 to ensure daily charts can trade regardless of session settings

## Testing
- `bash -lc 'grep -n "Skip session filtering" -n MQL4/Experts/CCTS_Breakout.mq4'`


------
https://chatgpt.com/codex/tasks/task_e_684c276069e0832f8b806ed080b928b5