### PR TITLE
Integrate Python ML signals

### DIFF
--- a/MQL4/Experts/CCTS_Breakout.mq4
+++ b/MQL4/Experts/CCTS_Breakout.mq4
@@ -279,6 +279,12 @@ void OnTick()
          exitSignalLong,
          exitSignalShort
       );
+      // Override with predictions from Python if available
+      ReadPythonSignals(PythonSignalFile,
+                       tradeSignalLong,
+                       tradeSignalShort,
+                       exitSignalLong,
+                       exitSignalShort);
      }
    else
      {

--- a/MQL4/Include/CCTS/CCTS_BaseIncludes.mqh
+++ b/MQL4/Include/CCTS/CCTS_BaseIncludes.mqh
@@ -31,6 +31,7 @@
 #include "..\CCTS\CCTS_LogTradesBacktest.mqh"
 #include "..\CCTS\CCTS_LogActions.mqh"
 #include "..\CCTS\CCTS_PersistentVariables.mqh"
+#include "..\CCTS\PythonSignalReader.mqh"
 
 
 #endif

--- a/MQL4/Include/CCTS/CCTS_Config.mqh
+++ b/MQL4/Include/CCTS/CCTS_Config.mqh
@@ -45,6 +45,7 @@ string        magicNumberString;
 
 string        tradeComment_1;
 string        tradeComment_2;
+const string  PythonSignalFile = "python_signals.csv";
 
 int           MagicNumber       = AutoMagic();
 

--- a/MQL4/Include/CCTS/PythonSignalReader.mqh
+++ b/MQL4/Include/CCTS/PythonSignalReader.mqh
@@ -1,0 +1,41 @@
+//+------------------------------------------------------------------+
+//|                                           PythonSignalReader.mqh |
+//|                            Utility to read ML-generated signals |
+//+------------------------------------------------------------------+
+#property strict
+
+#ifndef __PYTHON_SIGNAL_READER_MQH__
+#define __PYTHON_SIGNAL_READER_MQH__
+
+void ReadPythonSignals(
+   const string &fileName,
+   int &tradeSignalLong,
+   int &tradeSignalShort,
+   int &exitSignalLong,
+   int &exitSignalShort)
+  {
+   tradeSignalLong  = 0;
+   tradeSignalShort = 0;
+   exitSignalLong   = 0;
+   exitSignalShort  = 0;
+
+   int handle = FileOpen(fileName, FILE_READ | FILE_TXT);
+   if(handle == INVALID_HANDLE)
+      return;
+
+   string line = FileReadString(handle);
+   FileClose(handle);
+
+   string parts[];
+   int count = StringSplit(line, ',', parts);
+   if(count >= 4)
+     {
+      tradeSignalLong  = (int)StringToInteger(parts[0]);
+      tradeSignalShort = (int)StringToInteger(parts[1]);
+      exitSignalLong   = (int)StringToInteger(parts[2]);
+      exitSignalShort  = (int)StringToInteger(parts[3]);
+     }
+  }
+
+#endif
+//+------------------------------------------------------------------+

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ MQL4/
 │           ├── V1/                      # Volume indicators (e.g., OBV with MA)
 │           └── Ex1/                     # Exit indicators (e.g., Rex)
 │           └── IndicatorSetBreakout.mqh # Indicators used by EA
+python/
+├── train_model.py        # Train ML models
+└── generate_signals.py   # Create signals for the EA
 
 ```
 
@@ -60,6 +63,7 @@ Core Modules
 * 📒 **Trade Logging** – Built-in journaling for debugging and evaluation
 * 🧩 **Support for multiple strategies** – e.g., ICT concepts, divergence, Renko, pivot-based entries
 * 🔊 **Volume & Exit Indicators** – Includes the V1 OBV with MA filter and Ex1 Rex early-exit logic
+* 🤖 **Python ML integration** – Train models in Python and feed signals to the EA via `python_signals.csv`
 
 ---
 
@@ -106,6 +110,21 @@ pause
 ```
 
 Make sure to adjust the path to `metaeditor.exe` as needed.
+
+---
+
+## 🐍 Python Signal Workflow
+
+1. Prepare a CSV file with OHLC data and the four target columns.
+2. Install Python dependencies (`pandas`, `scikit-learn`, `joblib`), then train the models:
+   ```bash
+   python python/train_model.py data.csv --model model.pkl
+   ```
+3. Generate daily signals:
+   ```bash
+   python python/generate_signals.py latest.csv --model model.pkl --output MQL4/Files/python_signals.csv
+   ```
+4. Attach the EA to MT4 and it will read `python_signals.csv` on each tick.
 
 ---
 

--- a/python/generate_signals.py
+++ b/python/generate_signals.py
@@ -1,0 +1,38 @@
+import argparse
+import joblib
+import pandas as pd
+
+from train_model import prepare_features
+
+
+def generate_signals(model_path: str, data_path: str, output_path: str):
+    models = joblib.load(model_path)
+    df = pd.read_csv(data_path)
+    features, _ = prepare_features(df)
+    latest = features.iloc[-1:]
+
+    preds = {
+        name: int(models[name].predict(latest)[0])
+        for name in models.keys()
+    }
+
+    with open(output_path, "w") as f:
+        f.write(
+            f"{preds['tradeSignalLong']},{preds['tradeSignalShort']},{preds['exitSignalLong']},{preds['exitSignalShort']}"
+        )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate signals for the EA")
+    parser.add_argument("data", help="CSV with latest OHLC data")
+    parser.add_argument("--model", default="model.pkl", help="Trained model file")
+    parser.add_argument(
+        "--output",
+        default="../MQL4/Files/python_signals.csv",
+        help="Where to write the signal file",
+    )
+    args = parser.parse_args()
+
+    generate_signals(args.model, args.data, args.output)
+    print(f"Signals written to {args.output}")
+

--- a/python/train_model.py
+++ b/python/train_model.py
@@ -1,0 +1,40 @@
+import argparse
+import joblib
+import pandas as pd
+from sklearn.ensemble import GradientBoostingClassifier
+
+
+def prepare_features(df: pd.DataFrame) -> (pd.DataFrame, pd.DataFrame):
+    """Create simple technical features."""
+    df = df.copy()
+    df["return"] = df["Close"].pct_change().fillna(0)
+    df["ma_fast"] = df["Close"].rolling(5).mean()
+    df["ma_slow"] = df["Close"].rolling(20).mean()
+    df["ma_diff"] = df["ma_fast"] - df["ma_slow"]
+    df = df.dropna()
+    features = df[["return", "ma_fast", "ma_slow", "ma_diff"]]
+    return features, df
+
+
+def train(df: pd.DataFrame) -> dict:
+    features, df = prepare_features(df)
+    targets = df[["tradeSignalLong", "tradeSignalShort", "exitSignalLong", "exitSignalShort"]]
+    models = {}
+    for column in targets.columns:
+        model = GradientBoostingClassifier()
+        model.fit(features, targets[column])
+        models[column] = model
+    return models
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Train ML models for EA signals")
+    parser.add_argument("data", help="CSV with OHLC data and target signals")
+    parser.add_argument("--model", default="model.pkl", help="Output model file")
+    args = parser.parse_args()
+
+    data = pd.read_csv(args.data)
+    models = train(data)
+    joblib.dump(models, args.model)
+    print(f"Saved models to {args.model}")
+


### PR DESCRIPTION
## Summary
- add Python scripts for training models and generating signal files
- read ML output from `python_signals.csv` using new `PythonSignalReader` include
- include the reader in the base includes and expose filename constant
- update breakout expert to load Python predictions
- document new workflow and directory layout in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d85549d50832f826892786c1f0b97