### PR TITLE
Improve Python training utilities

### DIFF
--- a/MQL4/Include/CCTS/python/generate_signals.py
+++ b/MQL4/Include/CCTS/python/generate_signals.py
@@ -1,13 +1,6 @@
-# generate_signals.py
 #!/usr/bin/env python3
-import os
+"""Generate EA signal files from labeled CSVs and trained models."""
 import sys
-
-"""
-Auto-generate EA signal files named python_signals_<magic>.csv
-from signals_labeled_<magic>.csv and the corresponding model_<magic>.pkl.
-Includes structured logging, CSV error handling, and optional metadata output.
-"""
 import json
 import logging
 from pathlib import Path

--- a/MQL4/Include/CCTS/python/train_model.py
+++ b/MQL4/Include/CCTS/python/train_model.py
@@ -1,9 +1,5 @@
-# train_model.py
 #!/usr/bin/env python3
-"""
-Train ML models on labeled MT4 data and save artifacts with metadata.
-"""
-import os
+"""Train ML models on labeled MT4 data and save artifacts with metadata."""
 import sys
 import json
 import logging
@@ -46,17 +42,22 @@ PYTHON_MODEL_DIR = THIS_FILE.parent  # 'python' folder
 SEED = 42
 CONFIG_PATH = THIS_FILE.parent / "config.json"
 
-# Load hyperparameters from config.json if exists
-if CONFIG_PATH.exists():
-    with open(CONFIG_PATH) as f:
-        config = json.load(f)
-else:
-    config = {
+
+def load_config() -> dict:
+    """Return hyperparameter configuration."""
+    if CONFIG_PATH.exists():
+        with open(CONFIG_PATH) as f:
+            return json.load(f)
+    default = {
         "n_estimators": 100,
         "learning_rate": 0.1,
-        "max_depth": 3
+        "max_depth": 3,
     }
-    logging.info("Using default hyperparameters: %s", config)
+    logging.info("Using default hyperparameters: %s", default)
+    return default
+
+
+config = load_config()
 
 
 def prepare_features(df: pd.DataFrame) -> pd.DataFrame:

--- a/MQL4/Include/CCTS/python/watch_and_train.py
+++ b/MQL4/Include/CCTS/python/watch_and_train.py
@@ -1,17 +1,14 @@
-#watch_and_train.py
 #!/usr/bin/env python3
-import os
-import sys
-"""
-Polls MT4 "Files" folder every second for new signals_labeled_<magic>.csv,
-restarts MT4 if needed, retrains models, and regenerates python_signals_<magic>.csv.
-Includes a spinner and status messages to show activity.
-"""
+"""Watch for labeled CSVs and retrain models when new data arrives."""
 
+import sys
 import time
 import subprocess
-import itertools
+import logging
 from pathlib import Path
+
+from watchdog.observers import Observer
+from watchdog.events import PatternMatchingEventHandler
 
 # ──────────────────────────────────────────────────────────────────
 # Locate repository root and vendor folder
@@ -30,86 +27,105 @@ if REPO_ROOT is None:
 VENDOR = REPO_ROOT / "vendor"
 sys.path.insert(0, str(VENDOR))
 
+# Logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s: %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+
 # Paths
-MT4_FILES_DIR   = REPO_ROOT / "MQL4" / "Files"
-PYTHON_SCRIPTS  = REPO_ROOT / "MQL4" / "Include" / "CCTS" / "python"
-TRAIN_SCRIPT    = PYTHON_SCRIPTS / "train_model.py"
+MT4_FILES_DIR = REPO_ROOT / "MQL4" / "Files"
+PYTHON_SCRIPTS = REPO_ROOT / "MQL4" / "Include" / "CCTS" / "python"
+TRAIN_SCRIPT = PYTHON_SCRIPTS / "train_model.py"
 GENERATE_SCRIPT = PYTHON_SCRIPTS / "generate_signals.py"
 
 # Settings
-PYTHON_EXE     = "python"
+PYTHON_EXE = "python"
 SIGNALS_PREFIX = "signals_labeled_"
-MIN_ROWS       = 100     # adjust back up once testing is complete
-POLL_INTERVAL  = 1.0     # seconds
+MIN_ROWS = 100
 
 # Verify paths exist
-for p, name in [(MT4_FILES_DIR, "MT4 Files folder"),
-                (TRAIN_SCRIPT, "train_model.py"),
-                (GENERATE_SCRIPT, "generate_signals.py")]:
+for p, name in [
+    (MT4_FILES_DIR, "MT4 Files folder"),
+    (TRAIN_SCRIPT, "train_model.py"),
+    (GENERATE_SCRIPT, "generate_signals.py"),
+]:
     if not p.exists():
-        print(f"[watch_and_train] ERROR: {name} not found at {p}")
+        logging.error("%s not found at %s", name, p)
         sys.exit(1)
 
 # Launch MT4
 TERMINAL = Path(r"E:\MT4_4.1_STD_1\terminal.exe")
 if TERMINAL.exists():
-    print(f"[watch_and_train] Launching MT4: {TERMINAL} /portable")
+    logging.info("Launching MT4: %s /portable", TERMINAL)
     subprocess.Popen([str(TERMINAL), "/portable"])
 else:
-    print(f"[watch_and_train] WARNING: MT4 not found at {TERMINAL}")
+    logging.warning("MT4 not found at %s", TERMINAL)
 
-# Keep track of processed magic numbers
 processed = set()
-spinner = itertools.cycle(['|', '/', '-', '\\'])
 
-# Initial status message
-print(f"[watch_and_train] Watching for new signals_labeled_<magic>.csv in {MT4_FILES_DIR}...")
-print(f"[watch_and_train] Polling every {POLL_INTERVAL}s, will train once {MIN_ROWS}+ rows detected.")
 
-while True:
+def process_file(csv_path: Path):
+    fname = csv_path.name
+    magic = fname.replace(SIGNALS_PREFIX, "").replace(".csv", "")
+    if magic in processed:
+        return
+
+    # wait a bit for file to finish writing
+    time.sleep(0.5)
     try:
-        # Poll for new labeled files
-        for csv_path in MT4_FILES_DIR.glob(f"{SIGNALS_PREFIX}*.csv"):
-            fname = csv_path.name
-            magic = fname.replace(SIGNALS_PREFIX, "").replace(".csv", "")
+        with open(csv_path, "r") as f:
+            rows = sum(1 for _ in f) - 1
+    except Exception:
+        return
 
-            if magic in processed:
-                continue
+    if rows < MIN_ROWS:
+        return
 
-            try:
-                with open(csv_path, "r") as f:
-                    rows = sum(1 for _ in f) - 1
-            except Exception:
-                # File is still being written; skip for now
-                continue
+    logging.info("New file detected: %s (%d rows)", fname, rows)
+    ret = subprocess.run([PYTHON_EXE, str(TRAIN_SCRIPT), magic])
+    if ret.returncode != 0:
+        logging.error("train_model returned %s", ret.returncode)
+        processed.add(magic)
+        return
 
-            if rows < MIN_ROWS:
-                continue
+    ret = subprocess.run([PYTHON_EXE, str(GENERATE_SCRIPT), magic])
+    if ret.returncode != 0:
+        logging.error("generate_signals returned %s", ret.returncode)
+        processed.add(magic)
+        return
 
-            # Found a ready file – process it
-            print(f"[watch_and_train] New file detected: {fname} ({rows} rows) → training…")
-            ret = subprocess.run([PYTHON_EXE, str(TRAIN_SCRIPT), magic])
-            if ret.returncode != 0:
-                print(f"[watch_and_train] ERROR: train_model returned {ret.returncode}")
-                processed.add(magic)
-                continue
+    logging.info("✅ Pipeline complete for magic=%s", magic)
+    processed.add(magic)
 
-            ret2 = subprocess.run([PYTHON_EXE, str(GENERATE_SCRIPT), magic])
-            if ret2.returncode != 0:
-                print(f"[watch_and_train] ERROR: generate_signals returned {ret2.returncode}")
-                processed.add(magic)
-                continue
 
-            print(f"[watch_and_train] ✅ Pipeline complete for magic={magic}")
-            processed.add(magic)
+class CSVHandler(PatternMatchingEventHandler):
+    def __init__(self):
+        super().__init__(patterns=[f"{SIGNALS_PREFIX}*.csv"], ignore_directories=True)
 
-        # Spinner + waiting status
-        ch = next(spinner)
-        sys.stdout.write(f"Waiting for new bar in MT4 {ch}    \r")
-        sys.stdout.flush()
+    def on_created(self, event):
+        process_file(Path(event.src_path))
 
-        time.sleep(POLL_INTERVAL)
+    def on_modified(self, event):
+        process_file(Path(event.src_path))
 
+
+def main():
+    logging.info("Watching for new %s*.csv in %s", SIGNALS_PREFIX, MT4_FILES_DIR)
+    observer = Observer()
+    handler = CSVHandler()
+    observer.schedule(handler, str(MT4_FILES_DIR), recursive=False)
+    observer.start()
+    try:
+        while True:
+            time.sleep(1)
     except KeyboardInterrupt:
-        print("\n[watch_and_train] Stopped by user.")
-        break
+        logging.info("Stopped by user")
+    finally:
+        observer.stop()
+        observer.join()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- clean up imports and headers
- add helper to load config in `train_model`
- simplify `generate_signals` header
- rewrite `watch_and_train` to use `watchdog` for efficient directory watching

## Testing
- `python -m py_compile MQL4/Include/CCTS/python/train_model.py MQL4/Include/CCTS/python/generate_signals.py MQL4/Include/CCTS/python/watch_and_train.py`

------
https://chatgpt.com/codex/tasks/task_e_684ed162a090832f8fced0e9364fce31