### PR TITLE
Fix logging utils and remove unused flag

### DIFF
--- a/MQL4/Include/CCTS/CCTS_Config.mqh
+++ b/MQL4/Include/CCTS/CCTS_Config.mqh
@@ -30,7 +30,6 @@ input bool    UseBreakeven            = true;        // Enable/Disable breakeven
 input bool    Use_Tp_2                = false;       // Enable/Disable 2nd take profit or let second trade run
 
 extern string DispPanelHeader         = "-------------------------- Display Panel Settings--------------------------";
-input bool    EnablePrintLogs         = true;        // Enable/Disable logs
 input bool    ShowDisplayPanel        = true;        // Enable/Disable display panel
 
 // Global Variables

--- a/MQL4/Include/CCTS/CCTS_LogActions.mqh
+++ b/MQL4/Include/CCTS/CCTS_LogActions.mqh
@@ -10,6 +10,7 @@
 
 #include "..\stdlib.mqh"
 #include "..\CCTS\CCTS_LogErrors.mqh"
+#include "..\CCTS\CCTS_LogUtils.mqh"
 
 //+------------------------------------------------------------------+
 //|                                                                  |
@@ -87,6 +88,7 @@ void LogAction(string actionType, string context, string one = "", string two = 
 
    if(logToFile)
      {
+      EnsureLogsDirectory();
       bool fileExists = FileIsExist(logFileName); // Check if the file already exists
       int handle = FileOpen(logFileName, FILE_WRITE | FILE_READ | FILE_CSV);
 

--- a/MQL4/Include/CCTS/CCTS_LogErrors.mqh
+++ b/MQL4/Include/CCTS/CCTS_LogErrors.mqh
@@ -12,6 +12,7 @@
 #include "..\stderror.mqh"
 #include "..\stdlib.mqh"
 #include "CCTS_Config.mqh"
+#include "CCTS_LogUtils.mqh"
 
 //+------------------------------------------------------------------+
 void ErrorLog(string functionName, string context, string one = "", string two = "", string three = "",
@@ -131,6 +132,7 @@ void ErrorLog(string functionName, string context, string one = "", string two =
 
    if(logToFile)
      {
+      EnsureLogsDirectory();
       bool fileExists = FileIsExist(logFileName); // Check if the file exists
       int handle = INVALID_HANDLE;
       int maxRetries = 5;

--- a/MQL4/Include/CCTS/CCTS_LogTrades.mqh
+++ b/MQL4/Include/CCTS/CCTS_LogTrades.mqh
@@ -6,31 +6,41 @@
 #define __LOG_TRADES2_MQH__
 
 #include "CCTS_Config.mqh"
+#include "CCTS_LogUtils.mqh"
 
 string LogTradeFileName = "Logs/TradeHistory";
 
 void LogTrade()
   {
+   EnsureLogsDirectory();
    string csvFilename = LogTradeFileName + "_" + eaTitle + ".csv";
-   int    fileHandle  = FileOpen(csvFilename, FILE_WRITE|FILE_CSV, ",");
+   bool   isNewFile   = !FileIsExist(csvFilename);
+   int    fileHandle  = FileOpen(csvFilename,
+                                 FILE_READ | FILE_WRITE | FILE_CSV,
+                                 ',');
 
    if(fileHandle < 0)
      {
-      Print("Failed to create file: ", csvFilename);
+      Print("Failed to open file: ", csvFilename);
       return;
      }
 
-   // UTF-8 BOM
-   uchar bom[3] = {0xEF,0xBB,0xBF};
-   FileWriteArray(fileHandle, bom, 0, 3);
+   FileSeek(fileHandle, 0, SEEK_END);
 
-   // Header
-   FileWrite(fileHandle,
-             "EAName","EntryTime","ExitTime","Symbol","Timeframe","MagicNumber","TicketNumber","OrderType",
-             "LotSize","InitialRisk","RMultiple",
-             "OpenPrice","ClosePrice","TakeProfit","StopLoss",
-             "Profit","ProfitDirection","DurationDays","DurationHours",
-             "DurationMinutes","DealComment","ClosureReason");
+   if(isNewFile)
+     {
+      // UTF-8 BOM
+      uchar bom[3] = {0xEF,0xBB,0xBF};
+      FileWriteArray(fileHandle, bom, 0, 3);
+
+      // Header
+      FileWrite(fileHandle,
+                "EAName","EntryTime","ExitTime","Symbol","Timeframe","MagicNumber","TicketNumber","OrderType",
+                "LotSize","InitialRisk","RMultiple",
+                "OpenPrice","ClosePrice","TakeProfit","StopLoss",
+                "Profit","ProfitDirection","DurationDays","DurationHours",
+                "DurationMinutes","DealComment","ClosureReason");
+     }
 
    for(int i=OrdersHistoryTotal()-1; i>=0; i--)
      {

--- a/MQL4/Include/CCTS/CCTS_LogTradesBacktest.mqh
+++ b/MQL4/Include/CCTS/CCTS_LogTradesBacktest.mqh
@@ -6,11 +6,13 @@
 #define __LOG_TRADES_BACKTEST_MQH__
 
 #include <CCTS\CCTS_Config.mqh>  // defines extern string eaTitle
+#include <CCTS\CCTS_LogUtils.mqh>
 
 string LogBacktestTradeFileName = "Logs/BacktestTradeHistory";
 
 void LogTradeBacktest()
 {
+   EnsureLogsDirectory();
    // build full filename
    string csvFilename = LogBacktestTradeFileName + "_" + eaTitle + ".csv";
 

--- a/MQL4/Include/CCTS/CCTS_LogUtils.mqh
+++ b/MQL4/Include/CCTS/CCTS_LogUtils.mqh
@@ -1,0 +1,14 @@
+#ifndef __CCTS_LOG_UTILS_MQH__
+#define __CCTS_LOG_UTILS_MQH__
+
+void EnsureLogsDirectory()
+  {
+   string folder = "Logs";
+   if(!FileIsExist(folder))
+     {
+      if(!FolderCreate(folder))
+         Print("Failed to create logs directory: ", folder);
+     }
+  }
+
+#endif // __CCTS_LOG_UTILS_MQH__


### PR DESCRIPTION
## Summary
- drop unused `EnablePrintLogs` setting
- add helper `EnsureLogsDirectory`
- append to trade logs instead of overwriting
- ensure log directory exists in all logging modules

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v '^vendor/')`

------
https://chatgpt.com/codex/tasks/task_e_6850231ebd68832f8c1321607b318e9b